### PR TITLE
Pushing deregister back into agent.conf

### DIFF
--- a/templates/agent.conf.erb
+++ b/templates/agent.conf.erb
@@ -5,3 +5,7 @@ SERVER=https://www.dataloop.io
 
 # Your account API key
 API_KEY=<%= @api_key %>
+
+# Deregister node with dataloop when the agent stops?
+# Only 'no' will make this stop.
+DEREGISTER_ONSTOP=<%= @deregister_onstop %>

--- a/templates/dataloop-agent-deb.erb
+++ b/templates/dataloop-agent-deb.erb
@@ -18,6 +18,7 @@
 DESC="Dataloop Agent"
 API_KEY=
 SERVER=
+DEREGISTER_ONSTOP=
 USER=dataloop
 
 if [ -f /etc/dataloop/agent.conf ] ; then
@@ -58,10 +59,10 @@ do_stop()
   start-stop-daemon --pidfile $PIDFILE --oknodo --stop
   RC=$?
   
-  <% if @deregister_onstop -%>
-  log_daemon_msg "Deregistering dataloop-agent from $SERVER: "
-  su -c "$DAEMON $DAEMON_OPTS --deregister" $USER
-  <% end -%>
+  if [ "$DEREGISTER_ONSTOP" != no ]; then
+    log_daemon_msg "Deregistering dataloop-agent from $SERVER: "
+    su -c "$DAEMON $DAEMON_OPTS --deregister" $USER
+  fi
 
   [ $RC -eq 0 ] && rm -f $PIDFILE
   log_end_msg $RC

--- a/templates/dataloop-agent-rpm.erb
+++ b/templates/dataloop-agent-rpm.erb
@@ -14,6 +14,7 @@
 
 API_KEY=
 SERVER=
+DEREGISTER_ONSTOP=
 if [ -f /etc/dataloop/agent.conf ] ; then
     . /etc/dataloop/agent.conf
 fi
@@ -46,10 +47,10 @@ stop() {
   fi
   echo 'Stopping service…' >&2
 
-  <% if @deregister_onstop -%>
-  echo "Deregistering dataloop-agent from $SERVER: "
-  su -c "$SCRIPT --deregister" $RUNAS
-  <% end -%>
+  if [ "$DEREGISTER_ONSTOP" != no ]; then
+    echo "Deregistering dataloop-agent from $SERVER: "
+    su -c "$SCRIPT --deregister" $RUNAS
+  fi
 
   if [ $? -ne 0 ]; then
     echo "failed! "


### PR DESCRIPTION
To remove the deregister puppet variable from the init script to enable the init script to be delivered with the apt and rpm packages.
