### PR TITLE
fix Puppetfile to accept apt >= 1.4.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -18,7 +18,7 @@ metadata
 #   :git => 'git://github.com/puppetlabs/puppetlabs-ntp.git'
 
 # A module from a git branch/tag
-mod 'puppetlabs-apt', '=1.4.0' # , :git => 'https://github.com/puppetlabs/puppetlabs-apt.git'
+mod 'puppetlabs-apt', '>=1.4.0' # , :git => 'https://github.com/puppetlabs/puppetlabs-apt.git'
 
 # A module from Github pre-packaged tarball
 # mod 'puppetlabs-apache', '0.6.0', :github_tarball => 'puppetlabs/puppetlabs-apache'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -7,5 +7,5 @@ FORGE
 
 DEPENDENCIES
   puppetlabs-apt (>= 1.4.0)
-  puppetlabs-apt (= 1.4.0)
+  puppetlabs-apt (>= 1.4.0)
 


### PR DESCRIPTION
Installing dataloop-puppet with librarian-puppet caused some issues due to a dependency conflict with the `puppetlabs-apt` module version. 

As the version specified in `metadata.json` is already `>=1.4.0`, it seems safe to specify the same in the Puppetfile, which is used by librarian-puppet for dependency resolution. 
