### PR TITLE
Fixing logrotate script

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,7 +49,7 @@ class dataloop_agent(
 
   file { '/etc/logrotate.d/dataloop':
     ensure  => 'present',
-    content => 'puppet:///modules/dataloop_agent/dataloop.logrotate',
+    source  => 'puppet:///modules/dataloop_agent/dataloop.logrotate',
     owner   => 'root',
     group   => 'root',
     mode    => '0644',


### PR DESCRIPTION
Weird that I'm not a customer and I'm making this pull request(!), but we still the have the module in our puppet repo and dormant on our servers even though we're not using the service, and I noticed this error in the init.pp:

/etc/logrotate.d/dataloop, in the previous configuration will have a file with the contents "puppet:///modules/dataloop_agent/dataloop.logrotate".

The option to define the source of the file should be 'source', not 'content'.
