### PR TITLE
Fixes incorrect module install directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ If you don't already have it, import the puppetlabs-apt module to your puppet re
 
 `#> puppet module install puppetlabs-apt --version 1.7.0`
 
-And import this dataloop-agent module
+And import this dataloop-agent module. Since the module only exists on GitHub we manually download the source and install it to the users modulepath. The REVISION can be a commit, branch or tag.
 
-`#> puppet module install --module_repository https://github.com/dataloop/dataloop-puppet dataloop-agent`
+```
+#> cd [MODULEPATH]
+#> curl -L https://github.com/dataloop/dataloop-puppet/archive/[REVISION].tar.gz | sudo tar xz
+#> mv dataloop-puppet-[REVISION] dataloop_agent
+```
 
 Add the dataloop-agent module to your node's run list and pass in the api_key for your dataloop.io account so that your servers can communicate back.
 


### PR DESCRIPTION
This PR fixes the directions for module installation. Puppet's built-in module manager doesn't interact with repositories that don't conform to the expected Forge standard. Unfortunately, GitHub doesn't so you can't use it as a --module_repository. This adds some docs to manually download and install the module to the users modulepath!
