### PR TITLE
Ubuntu-Apt-Cleanup-20150729 : Cleaning up first run failures 

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,14 +1,15 @@
+# ::dataloop_agent::repo - configure dataloop agent repositories
 class dataloop_agent::repo(
   $gpg_key_url = 'https://download.dataloop.io/pubkey.gpg',
   $release = 'stable',
   ) {
 
   case $::operatingsystem {
-   'RedHat', 'CentOS', 'Fedora', 'Scientific', 'SL', 'SLC', 'Ascendos',
-   'CloudLinux', 'PSBM', 'OracleLinux', 'OVS', 'OEL', 'Amazon', 'XenServer': {
+    'RedHat', 'CentOS', 'Fedora', 'Scientific', 'SL', 'SLC', 'Ascendos',
+    'CloudLinux', 'PSBM', 'OracleLinux', 'OVS', 'OEL', 'Amazon', 'XenServer': {
   
       yumrepo { 'dataloop':
-        baseurl  => "https://download.dataloop.io/packages/${release}/rpm/$architecture",
+        baseurl  => "https://download.dataloop.io/packages/${release}/rpm/${::architecture}",
         descr    => 'Dataloop Repository',
         enabled  => 1,
         gpgkey   => $gpg_key_url,
@@ -22,23 +23,21 @@ class dataloop_agent::repo(
       }
 
     }
-   'Debian', 'Ubuntu': {
-    include apt
-    include apt::update
-
-
-      exec { 'apt-key dataloop':
-        command => "/usr/bin/wget -q ${gpg_key_url} -O -|/usr/bin/apt-key add -",
-        unless  => '/usr/bin/apt-key list|/bin/grep -c dataloop',
+    'Debian', 'Ubuntu': {
+      require ::apt
+      apt::key { 'dataloop':
+        id     => '095E8A4D6D9018DD45BD8E870008AA66113E2B8D',
+        source => $gpg_key_url,
       }
-  
       apt::source { 'dataloop':
-        location    => 'https://download.dataloop.io/deb',
-        release     => $release,
-        repos       => 'main',
-        include_src => false,
-        require     => Exec['apt-key dataloop'],
+        location => 'https://download.dataloop.io/deb',
+        release  => $release,
+        repos    => 'main',
+        require  => Apt::Key['dataloop'],
       }
+    }
+    default: {
+      warning("Module ${module_name} is not supported on ${::lsbdistid}")
     }
   }
 


### PR DESCRIPTION
- First run failures caused primarily by manual gpg key management via exec on Ubuntu and potentially other Debian based distros
- Without these changes, there is a guaranteed fail on first run due to chicken or egg problems
- Clean first runs are good :)
- Tested on Ubuntu 14.04.2, Puppet 3.8.1, and Puppetlabs-Apt Module 2.1.1
